### PR TITLE
Use `gh-valet` CLI to run Valet commands

### DIFF
--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Install Valet CLI
         shell: bash
         run: |
-          echo ${{ secrets.valet_ghcr_password }} | gh auth login --with-token
           gh extension install github/gh-valet
           gh valet update --username ${{ secrets.valet_ghcr_username }} --password ${{ secrets.valet_ghcr_password }}
       - uses: actions-ecosystem/action-add-labels@v1

--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -34,6 +34,8 @@ jobs:
         run: |
           gh extension install github/gh-valet
           gh valet update --username ${{ secrets.valet_ghcr_username }} --password ${{ secrets.valet_ghcr_password }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.valet_ghcr_password }}
       - uses: actions-ecosystem/action-add-labels@v1
         if: always()
         with:

--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -28,18 +28,22 @@ jobs:
     outputs:
       command: ${{ steps.prepare.outputs.command }}
       log-filename: ${{ steps.logs.outputs.filename }}
-    container:
-      image: ghcr.io/valet-customers/valet-cli:latest
-      credentials:
-        username: ${{ secrets.valet_ghcr_username }}
-        password: ${{ secrets.valet_ghcr_password }}
     steps:
+      - name: Install Valet CLI
+        shell: bash
+        run: |
+          echo ${{ secrets.valet_ghcr_password }} | gh auth login --with-token
+          gh extension install github/gh-valet
+          gh valet update --username ${{ secrets.valet_ghcr_username }} --password ${{ secrets.valet_ghcr_password }}
       - uses: actions-ecosystem/action-add-labels@v1
         if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: valet-running
       - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.1
       - name: Install dependencies
         run: bundle install --without development
       - name: Prepare arguments
@@ -58,18 +62,18 @@ jobs:
           fi
       - name: execute valet
         run: |
-          valet ${{ steps.prepare.outputs.command }} ${{ steps.prepare.outputs.provider }} \
+          gh valet ${{ steps.prepare.outputs.command }} ${{ steps.prepare.outputs.provider }} \
             ${{ steps.prepare.outputs.args }} \
-            --output-dir /data/output
+            --output-dir output
       - uses: actions/upload-artifact@v2
         if: always()
         with:
-          path: /data/output/
+          path: output/
           name: output
       - if: always()
         id: logs
         run: |
-          path=$(ls /data/output/log/*.log | head -1)
+          path=$(ls output/log/*.log | head -1)
           filename=$(basename "$path")
           echo "LOG_FILE_PATH=$path" >> $GITHUB_ENV
           echo "::set-output name=filename::$filename"

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,9 @@ source "https://rubygems.org"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem "require_all", "~> 3.0.0"
+gem "activesupport", "~> 7.0"
+gem "json",          "~> 2.6"
+gem "require_all",   "~> 3.0.0"
 
 group :development do
   gem "dotenv",              "~> 2.7.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4.1)
+    activesupport (7.0.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     ast (2.4.2)
     byebug (11.1.3)
     coderay (1.1.3)
@@ -20,8 +19,9 @@ GEM
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    json (2.6.2)
     method_source (1.0.0)
-    minitest (5.14.4)
+    minitest (5.15.0)
     parallel (1.21.0)
     parser (3.0.3.1)
       ast (~> 2.4.1)
@@ -70,16 +70,17 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.1)
-    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby
   x86_64-darwin-19
 
 DEPENDENCIES
+  activesupport (~> 7.0)
   dotenv (~> 2.7.6)
   factory_bot (~> 6.1)
   faker (~> 2.17)
+  json (~> 2.6)
   pry-byebug (~> 3.9)
   require_all (~> 3.0.0)
   rspec (~> 3.10)

--- a/cli.rb
+++ b/cli.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "require_all"
-require "pry" if ENV["VALET_CONTAINER"].nil?
+require "pry" if ENV["CI"].nil?
 require "json"
 
 require_all "lib"

--- a/lib/models/circle_ci/dry_run.rb
+++ b/lib/models/circle_ci/dry_run.rb
@@ -5,7 +5,6 @@ module CircleCI
     include IssueParser
 
     def initialize(issue_content, command)
-      # TODO: manually test this
       @organization = parameter_from_issue("Organization", issue_content)
       @project = command.options["project"]
     end


### PR DESCRIPTION
## What's changing?

This is updating the `issue_ops.yml` workflow to make use of the `github/gh-valet` cli extension instead of invoking commands directly from within the Valet container image. The benefit of making this update is so that path arguments for input files will not need to be relevant to the `/data` directory on the _container's_ filesystem, but rather will be relative to the root of this repository.

Closes github/valet#4250