### PR TITLE
Update the default values and get from secrets

### DIFF
--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -9,9 +9,9 @@ permissions:
   issues: write
 
 env:
-  GITHUB_INSTANCE_URL: https://github.com
+  GITHUB_INSTANCE_URL: ${{ secrets.GITHUB_INSTANCE_URL || 'https://github.com' }}
   GITHUB_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-  JENKINS_INSTANCE_URL: https://jenkout.westus2.cloudapp.azure.com
+  JENKINS_INSTANCE_URL: ${{ secrets.JENKINS_INSTANCE_URL }}
   JENKINS_USERNAME: ${{ secrets.jenkins_username }}
   JENKINS_ACCESS_TOKEN: ${{ secrets.jenkins_access_token }}
   JENKINSFILE_ACCESS_TOKEN: ${{ secrets.jenkinsfile_access_token }}


### PR DESCRIPTION
- JENKINS_INSTANCE_URL is hardcoded to https://jenkout.westus2.cloudapp.azure.com
- Updated it to retrieve from gh actions secrets.
- GITHUB_INSTANCE_URL - updated if it's not provided in secrets, it will default to https://github.com