### PR TITLE
Fixes to CircleCI Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/circle_ci.md
+++ b/.github/ISSUE_TEMPLATE/circle_ci.md
@@ -10,8 +10,7 @@ assignees: ""
 
 Provide the following required inputs:
 
-Organization:
-_The Circle CI organization to migrate pipelines from._
+Organization: _The Circle CI organization to migrate pipelines from._
 
 ## Available commands
 

--- a/.github/ISSUE_TEMPLATE/circle_ci.md
+++ b/.github/ISSUE_TEMPLATE/circle_ci.md
@@ -17,7 +17,7 @@ Organization: _The Circle CI organization to migrate pipelines from._
 The following commands can be executed by adding a comment to this issue:
 
 - `/audit`
-- `/dry-run --repository :repository-name`
-- `/migrate --repository :repository-name --target-url :github-repository-url`
+- `/dry-run --project :repository-name`
+- `/migrate --project :repository-name --target-url :github-repository-url`
 
 **Note**: If any options are missing, the command will not be successful.


### PR DESCRIPTION
There were a couple spots were I ran into issues using the Issue template documentation for CircleCI.

1. The CircleCI organization needs to appear on the same line or `parameter_from_issue` won't pick it up.
2. The `repository` argument in both `dry-run` and `migrate` is required to be `project` instead. I wasn't sure which one was desired, so I went with `project`. Happy to update the PR to officially make it `repository` however.

Let me know if my PR needs anythings else. ❤️ 